### PR TITLE
ci: skip some builds for dependabot pr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,11 +92,11 @@ install:
       SKIP_FULL_BUILD=$([[ "${MODIFIED_FILES}" = *"examples/full-airbnb/"* && ! "${VUE_TEMPLATE_TEST}" = full-airbnb ]])
       SKIP_FULL_AIRBNB_BUILD=$([[ "${MODIFIED_FILES}" = *"examples/full/"* && ! "${VUE_TEMPLATE_TEST}" = full ]])
 
-      echo $SKIP_MINIMAL_BUILD
-      echo $SKIP_FULL_BUILD
-      echo $SKIP_FULL_AIRBNB_BUILD
+      [[ $SKIP_MINIMAL_BUILD ]] && echo "Skip minimal build" || echo "Don't skip minimal build"
+      [[ $SKIP_FULL_BUILD ]] && echo "Skip full build" || echo "Don't skip full build"
+      [[ $SKIP_FULL_AIRBNB_BUILD ]] && echo "Skip full-airbnb build" || echo "Don't skip full-airbnb build"
 
-      if [[ SKIP_MINIMAL_BUILD || SKIP_FULL_BUILD || SKIP_FULL_AIRBNB_BUILD ]]; then 
+      if [[ $SKIP_MINIMAL_BUILD || $SKIP_FULL_BUILD || $SKIP_FULL_AIRBNB_BUILD ]]; then 
         echo -e "\\e[1;34mSkipping building.\\e[0m"
         exit 0
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,5 +118,8 @@ install:
       fi
     }
 
+before_script:
+  - git fetch --unshallow
+
 script:
   - (run_tests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,9 @@ install:
       MODIFIED_FILES=$(git --no-pager diff --name-only origin/master)
       echo $MODIFIED_FILES
 
-      SKIP_MINIMAL_BUILD=$($MODIFIED_FILES = *"examples/minimal/"* && ! "${VUE_TEMPLATE_TEST}" = minimal)
-      SKIP_FULL_BUILD=$($MODIFIED_FILES = *"examples/full-airbnb/"* && ! "${VUE_TEMPLATE_TEST}" = full-airbnb)
-      SKIP_FULL_AIRBNB_BUILD=$($MODIFIED_FILES = *"examples/full/"* && ! "${VUE_TEMPLATE_TEST}" = full)
+      SKIP_MINIMAL_BUILD=$("${MODIFIED_FILES}" = *"examples/minimal/"* && ! "${VUE_TEMPLATE_TEST}" = minimal)
+      SKIP_FULL_BUILD=$("${MODIFIED_FILES}" = *"examples/full-airbnb/"* && ! "${VUE_TEMPLATE_TEST}" = full-airbnb)
+      SKIP_FULL_AIRBNB_BUILD=$("${MODIFIED_FILES}" = *"examples/full/"* && ! "${VUE_TEMPLATE_TEST}" = full)
 
       echo $SKIP_MINIMAL_BUILD
       echo $SKIP_FULL_BUILD

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - VUE_TEMPLATE_TEST=full-airbnb
 
 before_install:
+  - git fetch --unshallow
   # Yarn
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"
@@ -83,7 +84,7 @@ install:
     dependabot_workflow() {
       set -e
 
-      MODIFIED_FILES=$(git --no-pager diff --name-only master)
+      MODIFIED_FILES=$(git --no-pager diff --name-only origin/master)
       echo $MODIFIED_FILES
 
       SKIP_MINIMAL_BUILD=$($MODIFIED_FILES = *"examples/minimal/"* && ! "${VUE_TEMPLATE_TEST}" = minimal)
@@ -117,9 +118,6 @@ install:
         exit $?
       fi
     }
-
-before_script:
-  - git fetch --unshallow
 
 script:
   - (run_tests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,9 @@ install:
       MODIFIED_FILES=$(git --no-pager diff --name-only origin/master)
       echo $MODIFIED_FILES
 
-      SKIP_MINIMAL_BUILD=$("${MODIFIED_FILES}" = *"examples/minimal/"* && ! "${VUE_TEMPLATE_TEST}" = minimal)
-      SKIP_FULL_BUILD=$("${MODIFIED_FILES}" = *"examples/full-airbnb/"* && ! "${VUE_TEMPLATE_TEST}" = full-airbnb)
-      SKIP_FULL_AIRBNB_BUILD=$("${MODIFIED_FILES}" = *"examples/full/"* && ! "${VUE_TEMPLATE_TEST}" = full)
+      SKIP_MINIMAL_BUILD=$([[ "${MODIFIED_FILES}" = *"examples/minimal/"* && ! "${VUE_TEMPLATE_TEST}" = minimal ]])
+      SKIP_FULL_BUILD=$([[ "${MODIFIED_FILES}" = *"examples/full-airbnb/"* && ! "${VUE_TEMPLATE_TEST}" = full-airbnb ]])
+      SKIP_FULL_AIRBNB_BUILD=$([[ "${MODIFIED_FILES}" = *"examples/full/"* && ! "${VUE_TEMPLATE_TEST}" = full ]])
 
       echo $SKIP_MINIMAL_BUILD
       echo $SKIP_FULL_BUILD

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
   - VUE_TEMPLATE_TEST=full-airbnb
 
 before_install:
-  - git fetch --unshallow
+  - git remote set-branches --add origin master
+  - git fetch
   # Yarn
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,22 +82,21 @@ install:
     }
 
   - |
-    dependabot_workflow() {
+    dependabot_workflow () {
       set -e
 
       MODIFIED_FILES=$(git --no-pager diff --name-only origin/master)
-      echo $MODIFIED_FILES
 
-      SKIP_MINIMAL_BUILD=$([[ "${MODIFIED_FILES}" = *"examples/minimal/"* && ! "${VUE_TEMPLATE_TEST}" = minimal ]])
-      SKIP_FULL_BUILD=$([[ "${MODIFIED_FILES}" = *"examples/full-airbnb/"* && ! "${VUE_TEMPLATE_TEST}" = full-airbnb ]])
-      SKIP_FULL_AIRBNB_BUILD=$([[ "${MODIFIED_FILES}" = *"examples/full/"* && ! "${VUE_TEMPLATE_TEST}" = full ]])
+      SKIP_MINIMAL_BUILD=$([[ ! "${MODIFIED_FILES}" = *"examples/minimal/"* && "${VUE_TEMPLATE_TEST}" = minimal ]] && echo 'true' || echo 'false')
+      SKIP_FULL_BUILD=$([[ ! "${MODIFIED_FILES}" = *"examples/full-airbnb/"* && "${VUE_TEMPLATE_TEST}" = full-airbnb ]] && echo 'true' || echo 'false')
+      SKIP_FULL_AIRBNB_BUILD=$([[ ! "${MODIFIED_FILES}" = *"examples/full/"* && "${VUE_TEMPLATE_TEST}" = full ]] && echo 'true' || echo 'false')
 
-      [[ $SKIP_MINIMAL_BUILD ]] && echo "Skip minimal build" || echo "Don't skip minimal build"
-      [[ $SKIP_FULL_BUILD ]] && echo "Skip full build" || echo "Don't skip full build"
-      [[ $SKIP_FULL_AIRBNB_BUILD ]] && echo "Skip full-airbnb build" || echo "Don't skip full-airbnb build"
+      echo -e "\\e[1;34mSkip minimal build? \\e[1;33m${SKIP_MINIMAL_BUILD}.\\e[0m"
+      echo -e "\\e[1;34mSkip full build? \\e[1;33m${SKIP_FULL_BUILD}.\\e[0m"
+      echo -e "\\e[1;34mSkip full-airbnb build? \\e[1;33m${SKIP_FULL_AIRBNB_BUILD}.\\e[0m"
 
-      if [[ $SKIP_MINIMAL_BUILD || $SKIP_FULL_BUILD || $SKIP_FULL_AIRBNB_BUILD ]]; then 
-        echo -e "\\e[1;34mSkipping building.\\e[0m"
+      if [[ $SKIP_MINIMAL_BUILD = 'true' || $SKIP_FULL_BUILD = 'true' || $SKIP_FULL_AIRBNB_BUILD = 'true' ]]; then
+        echo -e "\\e[1;34mThen skip building.\\e[0m"
         exit 0
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,22 @@ install:
     dependabot_workflow() {
       set -e
 
+      MODIFIED_FILES=$(git --no-pager diff --name-only master)
+      echo $MODIFIED_FILES
+
+      SKIP_MINIMAL_BUILD=$($MODIFIED_FILES = *"examples/minimal/"* && ! "${VUE_TEMPLATE_TEST}" = minimal)
+      SKIP_FULL_BUILD=$($MODIFIED_FILES = *"examples/full-airbnb/"* && ! "${VUE_TEMPLATE_TEST}" = full-airbnb)
+      SKIP_FULL_AIRBNB_BUILD=$($MODIFIED_FILES = *"examples/full/"* && ! "${VUE_TEMPLATE_TEST}" = full)
+
+      echo $SKIP_MINIMAL_BUILD
+      echo $SKIP_FULL_BUILD
+      echo $SKIP_FULL_AIRBNB_BUILD
+
+      if [[ SKIP_MINIMAL_BUILD || SKIP_FULL_BUILD || SKIP_FULL_AIRBNB_BUILD ]]; then 
+        echo -e "\\e[1;34mSkipping building.\\e[0m"
+        exit 0
+      fi
+
       cd examples/${VUE_TEMPLATE_TEST}
       tfold "Installing extension dependencies..." yarn
       [[ ! "${VUE_TEMPLATE_TEST}" =~ ^full ]] && echo -e "\\e[1;34mSkipping linting.\\e[0m"   || tfold "Linting..." yarn lint --fix       || exit $?


### PR DESCRIPTION
Now for Dependabot PR, it will:
- skip build "full" if "full" example has been updated
- skip build "full-airbnb" if "full-airbnb" example has been updated
- skip build "minimal" if from "minima" example has been updated

We gain 2 x ~30 seconds. It's good, but I'm sure we can improve that.