### PR TITLE
fix(tmpl): do not use vuex getter if vuex is disabled

### DIFF
--- a/template/src/background.js
+++ b/template/src/background.js
@@ -1,3 +1,8 @@
-{{#if store}}import store from './store'{{/if}}
+{{#if store}}
+import store from './store'
 
 alert(`Hello ${store.getters.foo}!`)
+{{else}}
+alert('Hello world!')
+{{/if}}
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #254   <!-- #-prefixed issue number(s), if any -->

Test was not failing because ESLint is not enabled for `minimal` scenario.