### PR TITLE
Update the version of eslint-plugin-vue for the compatibility of eslint@^5.x.x

### DIFF
--- a/examples/full-airbnb/package.json
+++ b/examples/full-airbnb/package.json
@@ -39,7 +39,7 @@
     "eslint-loader": "^2.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-prettier": "^2.6.2",
-    "eslint-plugin-vue": "^4.7.1",
+    "eslint-plugin-vue": "^5.0.0-beta.3",
     "file-loader": "^1.1.11",
     "husky": "^0.14.3",
     "mini-css-extract-plugin": "^0.4.1",

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -1,3 +1,3 @@
 # Project: Full
 
-This project has been generated with `vue init kocal/vue-web-extension full` command, following [minimal scenario](../../scenarios/minimal.json).
+This project has been generated with `vue init kocal/vue-web-extension full` command, following [full scenario](../../scenarios/full.json).

--- a/examples/full/package.json
+++ b/examples/full/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
-    "eslint-plugin-vue": "^4.7.1",
+    "eslint-plugin-vue": "^5.0.0-beta.3",
     "file-loader": "^1.1.11",
     "husky": "^0.14.3",
     "mini-css-extract-plugin": "^0.4.1",

--- a/template/package.json
+++ b/template/package.json
@@ -36,7 +36,7 @@
     "eslint": "^5.4.0",
     "eslint-friendly-formatter": "^4.0.1",
     "eslint-loader": "^2.1.0",
-    "eslint-plugin-vue": "^4.7.1",
+    "eslint-plugin-vue": "^5.0.0-beta.3",
     {{#if_eq lintConfig "standard"}}
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-promise": "^3.8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tests pass?   | yes
| Fixed tickets | ~

`eslint-plugin-vue@4.7.1` requires `eslint@^3.18.0` or `^4.0.0`, which is different from the `package.json` in `/template`. Thus, I update `eslint-plugin-vue` to "next" version for the compatibility of `eslint@^5.x.x`. Besides, I fix typo in `README.md` of full scenario example.