### PR TITLE
feat: use EJS on html files, inject process.env.* vars

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -78,6 +78,7 @@
     "copy-webpack-plugin": "^4.5.3",
     "cross-env": "^5.2.0",
     "css-loader": "^0.28.11",
+    "ejs": "^2.6.1",
     "file-loader": "^1.1.11",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.9.3",

--- a/template/src/options/options.html
+++ b/template/src/options/options.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <title>{{ name }} - Options</title>
   <link rel="stylesheet" href="options.css">
+  <% if (NODE_ENV === 'development') { %>
+  <!-- Load some resources only in development environment -->
+  <% } %>
 </head>
 <body>
   <div id="app"></div>

--- a/template/src/popup/popup.html
+++ b/template/src/popup/popup.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <title>Title</title>
   <link rel="stylesheet" href="popup.css">
+  <% if (NODE_ENV === 'development') { %>
+  <!-- Load some resources only in development environment -->
+  <% } %>
 </head>
 <body>
   <div id="app">

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const ejs = require('ejs');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WebpackShellPlugin = require('webpack-shell-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -60,8 +61,8 @@ const config = {
     }),
     new CopyWebpackPlugin([
       { from: 'icons', to: 'icons', ignore: ['icon.xcf'] },
-      { from: 'popup/popup.html', to: 'popup/popup.html' },{{#options}}
-      { from: 'options/options.html', to: 'options/options.html' },{{/options}}
+      { from: 'popup/popup.html', to: 'popup/popup.html', transform: transformHtml },{{#options}}
+      { from: 'options/options.html', to: 'options/options.html', transform: transformHtml },{{/options}}
       {
         from: 'manifest.json',
         to: 'manifest.json',
@@ -97,6 +98,12 @@ if (process.env.HMR === 'true') {
   config.plugins = (config.plugins || []).concat([
     new ChromeExtensionReloader(),
   ]);
+}
+
+function transformHtml(content) {
+  return ejs.render(content.toString(), {
+    ...process.env,
+  });
 }
 
 module.exports = config;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | ~   <!-- #-prefixed issue number(s), if any -->

In order to load Vue Devtools remote `<script>` (https://github.com/Kocal/vue-web-extension/issues/334#issuecomment-430491330) only for development environment, a good solution is to use a condition (with EJS) on HTML files.

That means you can write:
```html
<% if (NODE_ENV === 'development') { %>
<script src="http://localhost:8098"></script>
<% } %>
```