### PR TITLE
change font file zip to path '/fonts/'

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -56,6 +56,7 @@ const config = {
         loader: 'file-loader',
         options: {
           name: '[name].[ext]?emitFile=false',
+          outputPath: '/fonts/'
         },
       },
     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/Kocal/vue-web-extension/issues/444

element-ui icons were not handled well by webpack.