### PR TITLE
fix: fix images loading when using a relative path

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -45,7 +45,7 @@ const config = {
         use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader?indentedSyntax'],
       },
       {
-        test: /\.(png|jpg|gif|svg|ico)$/,
+        test: /\.(png|jpg|jpeg|gif|svg|ico)$/,
         loader: 'file-loader',
         options: {
           name: '[name].[ext]?emitFile=false',

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -48,16 +48,18 @@ const config = {
         test: /\.(png|jpg|jpeg|gif|svg|ico)$/,
         loader: 'file-loader',
         options: {
-          name: '[name].[ext]?emitFile=false',
+          name: '[name].[ext]',
           outputPath: '/images/',
+          emitFile: false,
         },
       },
       {
         test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
         loader: 'file-loader',
         options: {
-          name: '[name].[ext]?emitFile=false',
-          outputPath: '/fonts/'
+          name: '[name].[ext]',
+          outputPath: '/fonts/',
+          emitFile: false,
         },
       },
     ],

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -49,6 +49,7 @@ const config = {
         loader: 'file-loader',
         options: {
           name: '[name].[ext]?emitFile=false',
+          outputPath: '/images/',
         },
       },
       {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #466   <!-- #-prefixed issue number(s), if any -->

We specify an `outputPath` for making relative images import working, read more at https://github.com/Kocal/vue-web-extension/issues/466#issuecomment-521535779