### PR TITLE
Update webpack.config.js

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -25,7 +25,7 @@ const config = {
     rules: [
       {
         test: /\.vue$/,
-        loaders: 'vue-loader',
+        loader: 'vue-loader',
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
fix webpack property 'loaders' is not allowed

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Tests pass?   | yes    

<!--
fix webpack.config.js vue loader property 'loaders' is not allowed
-->
